### PR TITLE
稼働時間を早朝および夜に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ major update PRに`major`ラベル付与
 
 ### [schedule](https://github.com/funteractive-inc/renovate-config/blob/main/schedule.json)
 
-日本時間平日の 10:00 ~ 18:00 のみ稼働
+日本時間平日の 00:00 - 08:00, 20:00 - 24:00のみ稼働

--- a/schedule.json
+++ b/schedule.json
@@ -3,6 +3,7 @@
         ":timezone(Asia/Tokyo)"
     ],
     "schedule": [
-        "before 8am and after 8pm every weekday"
+        "before 8am every weekday",
+        "after 8pm every weekday"
     ]
 }

--- a/schedule.json
+++ b/schedule.json
@@ -3,6 +3,6 @@
         ":timezone(Asia/Tokyo)"
     ],
     "schedule": [
-        "after 10am and before 6pm every weekday"
+        "before 8am and after 8pm every weekday"
     ]
 }


### PR DESCRIPTION
稼働時間を勤務時間にするとslackのdevelopチャンネルの通知が流れやすくなってしまう。
これを回避するため、稼働時間を勤務時間外（08時以前および20時以降）に変更した。