### PR TITLE
minorバージョンに対してstabilityDaysを追加

### DIFF
--- a/default.json
+++ b/default.json
@@ -17,5 +17,8 @@
         "fileMatch": [
             "(^|/)Dockerfile-[^/]*$"
         ]
+    },
+    "minor": {
+        "stabilityDays": 3
     }
 }


### PR DESCRIPTION
マイナーバージョンがリリースされてPRが作られた場合に、PRは作られてCIは走るけど、指定した日数はpassしなくなる
→patchがリリースされたりするので待機時間を設ける意