### PR TITLE
GitHub Actionsのバージョンを自動でdigest固定してくれるようにする

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
     "extends": [
         "config:recommended",
         ":enableVulnerabilityAlertsWithLabel(security)",
+        "helpers:pinGitHubActionDigests",
         "github>funteractive-inc/renovate-config:schedule",
         "github>funteractive-inc/renovate-config:labelMajor",
         "github>funteractive-inc/renovate-config:automergePinPatch",


### PR DESCRIPTION
GHAのVersionをハッシュ固定にするPRを自動で出してくれる設定を足すPRです。
このヘルパーです→ https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating

config:best-practices[¶](https://docs.renovatebot.com/presets-config/#configbest-practices) には標準でついてるんですが、これを今は使ってなくrecommendedを使っていて、こっちには"helpers:pinGitHubActionDigests"は載ってないので自分で足す必要があります。

